### PR TITLE
Buffering input in day7

### DIFF
--- a/2022/day07/day07.go
+++ b/2022/day07/day07.go
@@ -141,7 +141,7 @@ func Main(stdout io.Writer) error {
 		return err
 	}
 
-	ch, err := input.ReadDataAsync(ctx, reader, 0)
+	ch, err := input.ReadDataAsync(ctx, reader, 10)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Allowing the reader to buffer 10 lines from the input shaves around 0.5 ms, a 25% decrease in time :D